### PR TITLE
Fix incorrect example of "from" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ This enables the following Gherkin for your scenarios to make assumptions on rec
 Given my inbox is empty
 Then I should see an email with subject "subject"
 Then I should see an email with body "body"
-Then I should see an email with from "sender@domain.example"
+Then I should see an email from "sender@domain.example"
 Then I should see an email with subject "subject" and body "body"
 Then I should see an email with subject "subject" and body "body" from "sender@domain.example"
 Then I should see an email with subject "subject" from "sender@domain.example"


### PR DESCRIPTION
This had `Then I should see an email with from "sender@domain.example"`, but the usage is just "email from" not "email with from".

- https://github.com/rpkamp/mailhog-behat-extension/blob/88fd7a8b393a91aa08c546fd8e335633eca33cad/src/Context/MailhogContext.php#L89
- https://github.com/rpkamp/mailhog-behat-extension/blob/88fd7a8b393a91aa08c546fd8e335633eca33cad/features/tests.feature#L7